### PR TITLE
Stripe hotfix

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -4,6 +4,7 @@ const morgan = require('morgan');
 const juices = require('./routes/juices');
 const ingredients = require('./routes/ingredients');
 const payments = require('./routes/payments');
+const orders = require('./routes/orders');
 const errorHandler = require('./error-handler');
 
 app.use(morgan('dev'));
@@ -28,6 +29,7 @@ app.use(express.static('./public'));
 
 app.use('/api/juices', juices);
 app.use('/api/ingredients', ingredients);
+app.use('/api/orders', orders);
 app.use('/api/payments', payments);
 
 app.use(errorHandler);

--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -1,0 +1,47 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const schema = new Schema({
+    name: {
+        type: String,
+        required: true
+    },
+    address: {
+        line_1: {
+            type: String,
+            required: true
+        },
+        line_2: {
+            type: String,
+            default: ''
+        },
+        city: {
+            type: String,
+            required: true
+        },
+        zip: {
+            type: Number,
+            required: true
+        },
+        state: {
+            type: String,
+            required: true
+        }
+    },
+    items: {
+        type: Array,
+        required: true
+    },
+    total: {
+        type: Number,
+        required: true
+    },
+    completed: {
+        type: Boolean,
+        default: false
+    }
+});
+
+module.exports = mongoose.model('Order', schema);
+
+//potentially add more validation in here to insure that state, city, zip, etc are within delivery range

--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -6,6 +6,10 @@ const schema = new Schema({
         type: String,
         required: true
     },
+    email: {
+        type: String,
+        required: true
+    },
     address: {
         line_1: {
             type: String,

--- a/lib/routes/orders.js
+++ b/lib/routes/orders.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const Order = require('../models/order');
+const bodyParser = require('body-parser').json();
+
+router
+    //maybe add in a query object so that we can filter the order by completed and not
+    .get('/', (req, res, next) => {
+        Order.find()
+            .then(orders => res.send(orders))
+            .catch(next);
+    })
+    .get('/:id', (req, res, next) => {
+        Order.findById(req.params.id)
+            .then(order => res.send(order))
+            .catch(next);
+    })
+    .post('/', bodyParser, (req, res, next) => {
+        new Order(req.body).save()
+            .then(saved => res.send(saved))
+            .catch(next);
+    });
+
+module.exports = router;

--- a/lib/routes/payments.js
+++ b/lib/routes/payments.js
@@ -10,14 +10,14 @@ router
     .post('/', bodyParser, (req, res) => { 
         console.log('Our metadata', req.body.metadata);
         const token = req.body.stripeToken;
-        const metadata = req.body.metadata;
+        const description = req.body.description;
         const chargeAmount = req.body.chargeAmount;
         //we will need to add the adress and itemized list somewherei n here
         const charge = stripe.charges.create({ //eslint-disable-line
             amount: chargeAmount,
             currency: 'usd',
             // description: 'Test charge',
-            metadata: metadata,
+            description: description,
             source: token,
         }, (err, charge) => { //eslint-disable-line
             if(err && err.type === 'StripeCardError') {

--- a/lib/routes/payments.js
+++ b/lib/routes/payments.js
@@ -8,13 +8,16 @@ const bodyParser = require('body-parser').json();
 
 router
     .post('/', bodyParser, (req, res) => { 
+        console.log('Our metadata', req.body.metadata);
         const token = req.body.stripeToken;
+        const metadata = req.body.metadata;
         const chargeAmount = req.body.chargeAmount;
         //we will need to add the adress and itemized list somewherei n here
         const charge = stripe.charges.create({ //eslint-disable-line
             amount: chargeAmount,
             currency: 'usd',
-            description: 'Test charge',
+            // description: 'Test charge',
+            metadata: metadata,
             source: token,
         }, (err, charge) => { //eslint-disable-line
             if(err && err.type === 'StripeCardError') {


### PR DESCRIPTION
Changed order schema so that the order now contains email. Stripe charge now contains the mongo id for order info in the description param. This may change later if I learn how to properly use metadata.